### PR TITLE
Two letters removed that are not in Slovene alpahbet

### DIFF
--- a/src/main/res/xml/qwertz.xml
+++ b/src/main/res/xml/qwertz.xml
@@ -3,7 +3,7 @@
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
     android:keyWidth="10%p"><!-- "android:keyWidth" specify the default width of a key. In this example, 10% of parent (the whole keyboard) -->
     
-    <Row android:keyWidth="8.3333%p">
+    <Row android:keyWidth="9.0909%p">
         <!-- Key attributes:
          "android:codes" : a comma separated unicode values of the keys. If you specify more than one code, then the other codes are accessible via multi-tap.
          "android:popupCharacters" : characters to show on long-press popup keyboard
@@ -23,11 +23,10 @@
         <Key android:codes="105" android:keyLabel="i" android:popupCharacters="8ìíîïłī" />
         <Key android:codes="111" android:keyLabel="o" android:popupCharacters="9òóôõöøőœō" />
         <Key android:codes="112" android:keyLabel="p" android:popupCharacters="0"/>
-        <Key android:codes="353" android:keyLabel="š" android:popupCharacters=""/>
-        <Key android:codes="273" android:keyLabel="đ" android:popupCharacters="" android:keyEdgeFlags="right"/>
+        <Key android:codes="353" android:keyLabel="š" android:popupCharacters=""/ android:keyEdgeFlags="right">
     </Row>
      
-    <Row android:keyWidth="8.3333%p" >
+    <Row android:keyWidth="9.0909%p" >
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="àáâãäåæą" android:keyEdgeFlags="left"/>
         <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßśŝ"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đ"/>
@@ -38,7 +37,6 @@
         <Key android:codes="107" android:keyLabel="k"/>
         <Key android:codes="108" android:keyLabel="l"/>
         <Key android:codes="269" android:keyLabel="č"/>
-        <Key android:codes="263" android:keyLabel="ć"/>
         <Key android:codes="382" android:keyLabel="ž" android:keyEdgeFlags="right"/>
     </Row>
     


### PR DESCRIPTION
I have removed letters ć and đ from layout because they are not part of Slovene alphabet and they take up a lot of horizontal space. These letters are from Croatian/Bosnian/Serbian(cyrilic) alphabets.