### PR TITLE
Fix missing accents and diacritics in Catalan layout

### DIFF
--- a/src/main/res/xml/catalan.xml
+++ b/src/main/res/xml/catalan.xml
@@ -5,19 +5,19 @@
     <Row android:keyWidth="9.09%p">
         <Key android:codes="113" android:keyLabel="q" android:keyEdgeFlags="left"/>
         <Key android:codes="119" android:keyLabel="w"/>
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="é"/>
+        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="éè"/>
         <Key android:codes="114" android:keyLabel="r"/>
         <Key android:codes="116" android:keyLabel="t"/>
         <Key android:codes="121" android:keyLabel="y"/>
-        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="ú"/>
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="í"/>
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="ó"/>
+        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="úü"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="íï"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="óò"/>
         <Key android:codes="112" android:keyLabel="p"/>
-        <Key android:codes="45" android:keyLabel="-" android:keyEdgeFlags="right"/>
+        <Key android:codes="45" android:keyLabel="-" android:popupCharacters="·" android:keyEdgeFlags="right"/>
     </Row>
     
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="á" android:keyEdgeFlags="left"/>
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="à" android:keyEdgeFlags="left"/>
         <Key android:codes="115" android:keyLabel="s"/>
         <Key android:codes="100" android:keyLabel="d"/>
         <Key android:codes="102" android:keyLabel="f"/>

--- a/src/main/res/xml/catalan.xml
+++ b/src/main/res/xml/catalan.xml
@@ -17,7 +17,7 @@
     </Row>
     
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="à" android:keyEdgeFlags="left"/>
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="àá" android:keyEdgeFlags="left"/>
         <Key android:codes="115" android:keyLabel="s"/>
         <Key android:codes="100" android:keyLabel="d"/>
         <Key android:codes="102" android:keyLabel="f"/>


### PR DESCRIPTION
As I said in #137, I have added the missing grave accents for 'a', 'e' and 'o'. Also added middledot quick access in '-' key to use which is commonly used in combination with letter 'l'.