### PR TITLE
Add padding to second row (horizontalGap)

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -2,10 +2,10 @@
 <resources>
     <string name="app_name">AnySoftKeyboard - Czech Language Pack</string>
     <string name="cs_qwerty_keyboard">Czech qwerty</string>
-    <string name="cs_qwerty_simple_keyboard">Simplified czech qwerty</string>
+    <string name="cs_qwerty_simple_keyboard">Czech</string>
     <string name="cs_qwertz_keyboard">Czech qwertz</string>
     <string name="cs_qwerty_description">Czech qwerty</string>
-    <string name="cs_qwerty_simple_description">Less number of keys to save space</string>
+    <string name="cs_qwerty_simple_description">Space saving QWERTY</string>
     <string name="cs_qwertz_description">Czech qwertz</string>
     <string name="dictionary">Czech Dictionary</string>
 </resources>

--- a/src/main/res/xml/cs_qwerty_simple.xml
+++ b/src/main/res/xml/cs_qwerty_simple.xml
@@ -4,39 +4,40 @@
     xmlns:ask="http://schemas.android.com/apk/res-auto"
     android:keyWidth="10%p">
 <Row>
-    <Key android:codes="q" android:popupCharacters="1" ask:hintLabel="1" android:keyEdgeFlags="left" />
+    <Key android:codes="q" android:popupCharacters="1" ask:hintLabel="1" android:keyEdgeFlags="left"/>
     <Key android:codes="w" android:popupCharacters="2" ask:hintLabel="2"/>
-    <Key android:codes="e" android:popupCharacters="3éëě€" ask:hintLabel="3"/>
-    <Key android:codes="r" android:popupCharacters="4řρ®" ask:hintLabel="4"/>
-    <Key android:codes="t" android:popupCharacters="5ťτ" ask:hintLabel="5"/>
-    <Key android:codes="y" android:popupCharacters="6ý" ask:hintLabel="6"/>
-    <Key android:codes="u" android:popupCharacters="7úůü" ask:hintLabel="7"/>
-    <Key android:codes="i" android:popupCharacters="8í" ask:hintLabel="8"/>
-    <Key android:codes="o" android:popupCharacters="9óöω" ask:hintLabel="9"/>
-    <Key android:codes="p" android:popupCharacters="0π" ask:hintLabel="0" android:keyEdgeFlags="right" />
+    <Key android:codes="e" android:popupCharacters="éëě3€" ask:hintLabel="3 €"/>
+    <Key android:codes="r" android:popupCharacters="ř4®" ask:hintLabel="4"/>
+    <Key android:codes="t" android:popupCharacters="ť5" ask:hintLabel="5"/>
+    <Key android:codes="y" android:popupCharacters="ý6" ask:hintLabel="6"/>
+    <Key android:codes="u" android:popupCharacters="úůü7" ask:hintLabel="7"/>
+    <Key android:codes="i" android:popupCharacters="í8" ask:hintLabel="8"/>
+    <Key android:codes="o" android:popupCharacters="óö9" ask:hintLabel="9"/>
+    <Key android:codes="p" android:popupCharacters="0" ask:hintLabel="0" android:keyEdgeFlags="right"/>
 </Row>
 <Row>
-    <Key android:codes="a" android:popupCharacters="\@áäα" ask:hintLabel="\@" android:keyEdgeFlags="left" />
-    <Key android:codes="s" android:popupCharacters="$šßσ" ask:hintLabel="\$"/>
-    <Key android:codes="d" android:popupCharacters="#%ďδ" ask:hintLabel="\$"/>
-    <Key android:codes="f" android:popupCharacters="^&amp;φ" ask:hintLabel="^ &amp;"/>
-    <Key android:codes="g" android:popupCharacters="`°γ" ask:hintLabel="` °"/>
+    <Key android:codes="a" android:popupCharacters="\@áä" ask:hintLabel="\@"
+         android:keyEdgeFlags="left" android:horizontalGap="5%p"/>
+    <Key android:codes="s" android:popupCharacters="š$ß" ask:hintLabel="$"/>
+    <Key android:codes="d" android:popupCharacters="ď#%" ask:hintLabel="# %"/>
+    <Key android:codes="f" android:popupCharacters="^&amp;" ask:hintLabel="^ &amp;"/>
+    <Key android:codes="g" android:popupCharacters="`°" ask:hintLabel="` °"/>
     <Key android:codes="h" android:popupCharacters="_~" ask:hintLabel="_ ~"/>
     <Key android:codes="j" android:popupCharacters="\\|" ask:hintLabel="\\ |"/>
     <Key android:codes="k" android:popupCharacters="([{" ask:hintLabel="("/>
-    <Key android:codes="l" android:popupCharacters=")]}ľλ" ask:hintLabel=")" android:keyEdgeFlags="right"/>
+    <Key android:codes="l" android:popupCharacters=")]}ľ" ask:hintLabel=")" android:keyEdgeFlags="right"/>
 </Row>
 <Row>
     <Key android:codes="-1" android:isModifier="true" android:keyWidth="15%p"
-         android:isSticky="true" android:keyEdgeFlags="left" />
-    <Key android:codes="z" android:popupCharacters="/÷ž" ask:hintLabel="/"/>
+         android:isSticky="true" android:keyEdgeFlags="left"/>
+    <Key android:codes="z" android:popupCharacters="ž/÷" ask:hintLabel="/"/>
     <Key android:codes="x" android:popupCharacters="*×" ask:hintLabel="*"/>
-    <Key android:codes="c" android:popupCharacters="-—č©" ask:hintLabel="—"/>
+    <Key android:codes="c" android:popupCharacters="č-—©" ask:hintLabel="—"/>
     <Key android:codes="v" android:popupCharacters="+±" ask:hintLabel="+"/>
-    <Key android:codes="b" android:popupCharacters="=≠β" ask:hintLabel="="/>
-    <Key android:codes="n" android:popupCharacters="&lt;ň" ask:hintLabel="&lt;"/>
-    <Key android:codes="m" android:popupCharacters="&gt;µ" ask:hintLabel="&gt;"/>
+    <Key android:codes="b" android:popupCharacters="=≠" ask:hintLabel="="/>
+    <Key android:codes="n" android:popupCharacters="ň&lt;" ask:hintLabel="&lt;"/>
+    <Key android:codes="m" android:popupCharacters="&gt;" ask:hintLabel="&gt;"/>
     <Key android:codes="-5" android:keyWidth="15%p"
-         android:keyEdgeFlags="right" android:isRepeatable="true" />
+         android:keyEdgeFlags="right" android:isRepeatable="true"/>
 </Row>
 </Keyboard>


### PR DESCRIPTION
Also:
- Remove greek letters, which are usually not used in Czechia, except math
- Fix hints for 's' and 'd'
- Change name of the keyboard to Czech because when switching to number keyboard, the button to get back to the Czech keyboard has no caption. I've figured from the other keyboards that in order for this button to have a caption, the name of the keyboard needs to have one word only.