### PR TITLE
Compact Dvorak layout

### DIFF
--- a/languages/english/pack/src/main/res/values/english_pack_strings.xml
+++ b/languages/english/pack/src/main/res/values/english_pack_strings.xml
@@ -4,6 +4,7 @@
     <string name="english_keyboard_symbols_description">QWERTY Latin keyboard with symbols (on long press)</string>
     <string name="dvorak_keyboard_description">Dvorak layout. Created with Stephen Paul Weber</string>
     <string name="compact_keyboard_description">Compact in portrait</string>
+    <string name="compact_dvorak_keyboard_description">Compact Dvorak in portrait</string>
     <string name="compact_keyboard_16keys_description">16 keys English layout</string>
     <string name="terminal_keyboard_description">Created with bittrance</string>
     <string name="colemak_keyboard_description">Colemak layout. Created with Hugo Lopes</string>

--- a/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
+++ b/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
@@ -8,6 +8,7 @@
     <string name="english_keyboard_symbols">English</string>
     <string name="dvorak_keyboard">Dvorak</string>
     <string name="compact_keyboard">EN Compact</string>
+    <string name="compact_dvorak_keyboard">Dv Compact</string>
     <string name="compact_keyboard_16keys">EN Keypad</string>
     <string name="terminal_keyboard">Terminal</string>
     <string name="colemak_keyboard">Colemak</string>

--- a/languages/english/pack/src/main/res/xml/dvorak_compact.xml
+++ b/languages/english/pack/src/main/res/xml/dvorak_compact.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyWidth="20%p">
+
+    <!-- Left hand of the Dvorak layout. Primaries: home-row, secondaries: bottom-row -->
+    <Row>
+        <Key android:codes="97" android:keyLabel="a" android:keyEdgeFlags="left"/>
+        <Key android:codes="111,113" android:keyLabel="oq"/>
+        <Key android:codes="101,106" android:keyLabel="ej"/>
+        <Key android:codes="117,107" android:keyLabel="uk"/>
+        <Key android:codes="105,120" android:keyLabel="ix" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <!-- Right hand of the Dvorak layout. Primaries: home-row, secondaries: bottom-row -->
+    <Row>
+        <Key android:codes="100,98" android:keyLabel="db" android:keyEdgeFlags="left"/>
+        <Key android:codes="104,109" android:keyLabel="hm"/>
+        <Key android:codes="116,119" android:keyLabel="tw"/>
+        <Key android:codes="110,118" android:keyLabel="nv"/>
+        <Key android:codes="115,122" android:keyLabel="sz" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <!-- Top-row of the Dvorak layout. -->
+    <Row>
+        <Key android:keyWidth="15%p" android:codes="-1"
+             android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:horizontalGap="5%p"
+             android:keyWidth="15%p" android:codes="112,121" android:keyLabel="py"/>
+        <Key android:keyWidth="15%p" android:codes="102,103" android:keyLabel="fg"/>
+        <Key android:keyWidth="15%p" android:codes="99,114" android:keyLabel="cr"/>
+        <Key android:keyWidth="15%p" android:codes="108" android:keyLabel="l"/>
+        <Key android:horizontalGap="5%p"
+             android:keyWidth="15%p" android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>

--- a/languages/english/pack/src/main/res/xml/english_keyboards.xml
+++ b/languages/english/pack/src/main/res/xml/english_keyboards.xml
@@ -26,15 +26,22 @@
               layoutResId="@xml/dvorak" id="4100d602-ba06-40e5-b169-61881b065def"
               defaultDictionaryLocale="en" description="@string/dvorak_keyboard_description"
               index="5"/>
+    <Keyboard nameResId="@string/compact_dvorak_keyboard" iconResId="@drawable/ic_status_english"
+              layoutResId="@xml/dvorak_compact" landscapeResId="@xml/dvorak"
+              id="53baf0a3-389d-4257-815b-5820d7d219f7"
+              defaultDictionaryLocale="en" description="@string/compact_dvorak_keyboard_description"
+              index="6" />
     <Keyboard nameResId="@string/colemak_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/colemak" id="86770389-9f38-4654-9e29-68d503410fcd"
               defaultDictionaryLocale="en" description="@string/colemak_keyboard_description"
-              index="6"/>
+              index="7"/>
     <Keyboard nameResId="@string/workman_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/workman" id="37334220-b0ca-11e8-8c82-0b99ca86e03e"
               defaultDictionaryLocale="en" description="@string/workman_keyboard_description"
-              index="7"/>
-    <Keyboard nameResId="@string/terminal_keyboard" layoutResId="@xml/terminal"
-              id="b1c24b40-02ce-4857-9fb8-fb9e4e3b4318" index="8" description="@string/terminal_keyboard_description"/>
+              index="8"/>
+    <Keyboard nameResId="@string/terminal_keyboard"
+              layoutResId="@xml/terminal" id="b1c24b40-02ce-4857-9fb8-fb9e4e3b4318"
+              description="@string/terminal_keyboard_description"
+              index="9"/>
 
 </Keyboards>


### PR DESCRIPTION
A keyboard for Dvorak users with small screens or fat fingers.
This layout preserves some strengths of the Dvorak layout. It provides
easy access to the most common keys and common bigrams are dispersed.
At the same time, this keyboard is recognizable (once you see what is
happening) for those familiar with the Dvorak layout.