### PR TITLE
Fix flag path & relative links in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ subprojects {
 
         //PUBLISH TO PLAY-STORE
         if (project.plugins.hasPlugin('com.android.application')) {
-            def image = "<img src='${project.parent.name}/apk/flag/{{IMAGE_FILENAME}}' height='16'>&nbsp;"
+            def image = "<img src='languages/${project.parent.name}/apk/flag/{{IMAGE_FILENAME}}' height='16'>&nbsp;"
             if (project.file("flag/flag.png").exists()) {
                 image = image.replace("{{IMAGE_FILENAME}}", "flag.png")
             } else if (project.file("flag/flag.svg").exists()) {
@@ -111,7 +111,7 @@ subprojects {
             } else {
                 image = ""
             }
-            def packReadMeDetails = "* ${image}${languageName.capitalize()}: [Source](https://github.com/AnySoftKeyboard/LanguagePack/tree/master/languages/${project.parent.name})"
+            def packReadMeDetails = "* ${image}${languageName.capitalize()}: [Source](languages/${project.parent.name})"
 
             project.android {
                 signingConfigs {


### PR DESCRIPTION
The directory `languages` was missing in the path.
Since relative link is used in flags, I also modified it in source link.