### PR TITLE
Define candidate_strip_fading_edge_length fallback values.

### DIFF
--- a/themes/classic_pc/pack/src/main/res/values/dimens.xml
+++ b/themes/classic_pc/pack/src/main/res/values/dimens.xml
@@ -29,5 +29,6 @@
     <dimen name="key_text_size">21sp</dimen>
     <dimen name="key_label_text_size">14sp</dimen>
     <dimen name="candidate_strip_height">36dip</dimen>
+    <dimen name="candidate_strip_fading_edge_length">63dip</dimen>
     <dimen name="candidate_font_height">18sp</dimen>
 </resources>

--- a/themes/ics/pack/src/main/res/values/dimens.xml
+++ b/themes/ics/pack/src/main/res/values/dimens.xml
@@ -29,5 +29,6 @@
     <dimen name="key_text_size">21sp</dimen>
     <dimen name="key_label_text_size">14sp</dimen>
     <dimen name="candidate_strip_height">36dip</dimen>
+    <dimen name="candidate_strip_fading_edge_length">63dip</dimen>
     <dimen name="candidate_font_height">18sp</dimen>
 </resources>

--- a/themes/israel64/pack/src/main/res/values/dimens.xml
+++ b/themes/israel64/pack/src/main/res/values/dimens.xml
@@ -29,6 +29,7 @@
     <dimen name="key_text_size">21sp</dimen>
     <dimen name="key_label_text_size">14sp</dimen>
     <dimen name="candidate_strip_height">36dip</dimen>
+    <dimen name="candidate_strip_fading_edge_length">63dip</dimen>
     <dimen name="candidate_font_height">18sp</dimen>
     <!-- 
     <dimen name="key_top_inset">1dp</dimen>

--- a/themes/three_d/pack/src/main/res/values/dimens.xml
+++ b/themes/three_d/pack/src/main/res/values/dimens.xml
@@ -29,5 +29,6 @@
     <dimen name="key_text_size">21sp</dimen>
     <dimen name="key_label_text_size">14sp</dimen>
     <dimen name="candidate_strip_height">36dip</dimen>
+    <dimen name="candidate_strip_fading_edge_length">63dip</dimen>
     <dimen name="candidate_font_height">18sp</dimen>
 </resources>


### PR DESCRIPTION
Define this dimension in the fallback values set for styles
which don't do so. Resolves a MissingDefaultResource lint
for these themes.

Need this to get a successful build, but I haven't done much Android development, so maybe there's a better fix?