### PR TITLE
Add characters used in semitic transliteration

### DIFF
--- a/languages/english/pack/src/main/res/xml/popup_16keys_abc.xml
+++ b/languages/english/pack/src/main/res/xml/popup_16keys_abc.xml
@@ -4,13 +4,14 @@
           android:keyWidth="15%p"
           android:keyHeight="@integer/key_normal_height">
     <Row android:rowEdgeFlags="top">
-        <!-- 2àáâãäåæą -->
+        <!-- 2àáâãāäåæą -->
         <Key android:codes="50" android:keyEdgeFlags="left"/>
         <Key android:codes="224"/>
         <Key android:codes="225"/>
         <Key android:codes="226"/>
         <Key android:codes="227"/>
         <Key android:codes="228"/>
+        <Key android:codes="257"/>
         <Key android:codes="229"/>
         <Key android:codes="230"/>
         <Key android:codes="261" android:keyEdgeFlags="right"/>

--- a/languages/english/pack/src/main/res/xml/qwerty_with_symbols.xml
+++ b/languages/english/pack/src/main/res/xml/qwerty_with_symbols.xml
@@ -18,7 +18,7 @@
     </Row>
 
     <Row>
-        <Key android:codes="a" android:popupCharacters="\@àáâãäåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
+        <Key android:codes="a" android:popupCharacters="\@àáâãāäåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
         <Key android:codes="s" android:popupCharacters="$§ßśŝš" ask:hintLabel="$"/>
         <Key android:codes="d" android:popupCharacters="#%đď" ask:hintLabel="# %"/>
         <Key android:codes="f" android:popupCharacters="^\u0026" ask:hintLabel="^ \u0026"/>

--- a/languages/english/pack/src/main/res/xml/qwerty_with_symbols.xml
+++ b/languages/english/pack/src/main/res/xml/qwerty_with_symbols.xml
@@ -9,7 +9,7 @@
         <Key android:codes="w" android:popupCharacters="2²₂ŵ" ask:hintLabel="2"/>
         <Key android:codes="e" android:popupCharacters="3³₃èéêëęē€" ask:hintLabel="3"/>
         <Key android:codes="r" android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4"/>
-        <Key android:codes="t" android:popupCharacters="5ť" ask:hintLabel="5"/>
+        <Key android:codes="t" android:popupCharacters="5ťṭṯ" ask:hintLabel="5"/>
         <Key android:codes="y" android:popupCharacters="6ýÿ" ask:hintLabel="6"/>
         <Key android:codes="u" android:popupCharacters="7ùúûüŭűūµ" ask:hintLabel="7"/>
         <Key android:codes="i" android:popupCharacters="8ìíîïłīι*" ask:hintLabel="8"/>
@@ -19,15 +19,15 @@
 
     <Row>
         <Key android:codes="a" android:popupCharacters="\@àáâãāäåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
-        <Key android:codes="s" android:popupCharacters="$§ßśŝš" ask:hintLabel="$"/>
-        <Key android:codes="d" android:popupCharacters="#%đď" ask:hintLabel="# %"/>
+        <Key android:codes="s" android:popupCharacters="$§ßśŝšṣ" ask:hintLabel="$"/>
+        <Key android:codes="d" android:popupCharacters="#%đďḏ" ask:hintLabel="# %"/>
         <Key android:codes="f" android:popupCharacters="^\u0026" ask:hintLabel="^ \u0026"/>
         <Key android:codes="g" android:popupCharacters="`°ĝ" ask:hintLabel="` °"/>
-        <Key android:codes="h" android:popupCharacters="_~ĥ" ask:hintLabel="_ ~"/>
+        <Key android:codes="h" android:popupCharacters="_~ĥḥḫẖ" ask:hintLabel="_ ~"/>
         <Key android:codes="j" android:popupCharacters="\\|ĵ" ask:hintLabel="\\ |"/>
-        <Key android:codes="k" android:popupCharacters="([{" ask:hintLabel="("/>
-        <Key android:codes="l" android:popupCharacters=")]}ľĺł£" ask:hintLabel=")"/>
-        <Key ask:isFunctional="true" android:codes="\u0027" android:popupCharacters="\u0022"
+        <Key android:codes="k" android:popupCharacters="([{⸢" ask:hintLabel="("/>
+        <Key android:codes="l" android:popupCharacters=")]}⸣ľĺł£" ask:hintLabel=")"/>
+        <Key ask:isFunctional="true" android:codes="\u0027" android:popupCharacters="ʾʿʻ\u0022"
              android:keyEdgeFlags="right"/>
     </Row>
 

--- a/languages/french/pack/src/main/res/xml/azerty.xml
+++ b/languages/french/pack/src/main/res/xml/azerty.xml
@@ -16,7 +16,7 @@
          "android:isRepeatable" : true/false (default is false) whether this key repeats printing on long press (like the backspace). Setting this to true will disable the long-press (android:popupCharacters) functionality
          "android:keyWidth" : specify the width of this key
          -->
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="1àá@âãäåæą¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="1àá@âãäåæąā¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
         <Key android:codes="122" android:keyLabel="z" android:popupCharacters="2żžź²₂" ask:hintLabel="2"/>
         <Key android:codes="101" android:keyLabel="e" android:popupCharacters="3èé€êëęē³₃" ask:hintLabel="3"/>
         <Key android:codes="114" android:keyLabel="r" android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4"/>

--- a/languages/french/pack/src/main/res/xml/azerty_accents.xml
+++ b/languages/french/pack/src/main/res/xml/azerty_accents.xml
@@ -16,7 +16,7 @@
          "android:isRepeatable" : true/false (default is false) whether this key repeats printing on long press (like the backspace). Setting this to true will disable the long-press (android:popupCharacters) functionality
          "android:keyWidth" : specify the width of this key
          -->
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="à1á@âãäåæą¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="à1á@âãäåæąā¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
         <Key android:codes="122" android:keyLabel="z" android:popupCharacters="2żžź²₂" ask:hintLabel="2"/>
         <Key android:codes="101" android:keyLabel="e" android:popupCharacters="éè3€êëęē³₃" ask:hintLabel="3"/>
         <Key android:codes="114" android:keyLabel="r" android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4"/>

--- a/languages/french/pack/src/main/res/xml/azerty_with_hyphen.xml
+++ b/languages/french/pack/src/main/res/xml/azerty_with_hyphen.xml
@@ -16,7 +16,7 @@
          "android:isRepeatable" : true/false (default is false) whether this key repeats printing on long press (like the backspace). Setting this to true will disable the long-press (android:popupCharacters) functionality
          "android:keyWidth" : specify the width of this key
          -->
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="1àá@âãäåæą¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="1àá@âãäåæąā¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
         <Key android:codes="122" android:keyLabel="z" android:popupCharacters="2żžź²₂" ask:hintLabel="2"/>
         <Key android:codes="101" android:keyLabel="e" android:popupCharacters="3èé€êëęē³₃" ask:hintLabel="3"/>
         <Key android:codes="114" android:keyLabel="r" android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4"/>


### PR DESCRIPTION
I use these for my work on ancient languages, but they're likely generally useful for occasional words from other languages. I hope you'll consider including them for general use.

* Make the English and French layouts consistently provide `ā`.
* Add extra characters useful in Semitic language transliteration to the English 'qwerty with symbols' layout.