### PR TITLE
Changed the default german ios-like layout to android-like aosp layout

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -3,8 +3,10 @@
 <resources>
 	<string name="app_name">AnySoftKeyboard - German Language Pack</string>
   <string name="de_keyboard">German</string>
+  <string name="de_keyboard_extend">German extended</string>
   <string name="de_keyboard_broad">German broad</string>
   <string name="de_keyboard_extra">German broad+</string>
+  <string name="de_keyboard_qwerty">German qwerty</string>
   <string name="german_dictionary">German</string>
   <string name="dictionary_name">German</string>
   <string name="keyboard_name">German</string>

--- a/src/main/res/xml/de_qwerty.xml
+++ b/src/main/res/xml/de_qwerty.xml
@@ -11,7 +11,7 @@
         <Key android:codes="101" android:keyLabel="e" android:popupCharacters="€3èéêëęē"/>
         <Key android:codes="114" android:keyLabel="r" android:popupCharacters="4"/>
         <Key android:codes="116" android:keyLabel="t" android:popupCharacters="5"/>
-        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="6żžź"/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="6ýÿ"/>
         <Key android:codes="117" android:keyLabel="u" android:popupCharacters="ü7ùúûũūŭű"/>
         <Key android:codes="105" android:keyLabel="i" android:popupCharacters="8ìíîïłī"/>
         <Key android:codes="111" android:keyLabel="o" android:popupCharacters="ö9òóôõōøœő"/>
@@ -32,7 +32,7 @@
     
     <Row>
         <Key android:codes="-1" android:keyWidth="15%p" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="ýÿ"/>
+        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="żžź"/>
         <Key android:codes="120" android:keyLabel="x" android:popupCharacters=""/>
         <Key android:codes="99" android:keyLabel="c" android:popupCharacters="çćĉč"/>
         <Key android:codes="118" android:keyLabel="v" android:popupCharacters=""/>

--- a/src/main/res/xml/de_qwertz_extend.xml
+++ b/src/main/res/xml/de_qwertz_extend.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyWidth="10%p">
+    
+    <Row android:keyWidth="9.09%p">
+        <Key android:codes="113" android:keyLabel="q" android:popupCharacters="" android:keyEdgeFlags="left"/>
+        <Key android:codes="119" android:keyLabel="w"  android:popupCharacters=""/>
+        <Key android:codes="101" android:keyLabel="e"  android:popupCharacters="€"/>
+        <Key android:codes="114" android:keyLabel="r"  android:popupCharacters=""/>
+        <Key android:codes="116" android:keyLabel="t"  android:popupCharacters=""/>
+        <Key android:codes="122" android:keyLabel="z"  android:popupCharacters=""/>
+        <Key android:codes="117" android:keyLabel="u"  android:popupCharacters=""/>
+        <Key android:codes="105" android:keyLabel="i"  android:popupCharacters=""/>
+        <Key android:codes="111" android:keyLabel="o"  android:popupCharacters=""/>
+        <Key android:codes="112" android:keyLabel="p"  android:popupCharacters=""/>
+        <Key android:codes="252" android:keyLabel="ü" android:popupCharacters="" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row android:keyWidth="9.09%p">
+        <Key android:codes="97" android:keyLabel="a"  android:popupCharacters="" android:keyEdgeFlags="left"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters=""/>
+        <Key android:codes="100" android:keyLabel="d" android:popupCharacters=""/>
+        <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
+        <Key android:codes="103" android:keyLabel="g" android:popupCharacters=""/>
+        <Key android:codes="104" android:keyLabel="h" android:popupCharacters=""/>
+        <Key android:codes="106" android:keyLabel="j" android:popupCharacters=""/>
+        <Key android:codes="107" android:keyLabel="k" android:popupCharacters=""/>
+        <Key android:codes="108" android:keyLabel="l" android:popupCharacters=""/>
+        <Key android:codes="246" android:keyLabel="ö" android:popupCharacters=""/>
+        <Key android:codes="228" android:keyLabel="ä" android:popupCharacters="" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row>
+        <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters=""/>
+        <Key android:codes="120" android:keyLabel="x" android:popupCharacters=""/>
+        <Key android:codes="99" android:keyLabel="c" android:popupCharacters=""/>
+        <Key android:codes="118" android:keyLabel="v" android:popupCharacters=""/>
+        <Key android:codes="98" android:keyLabel="b" android:popupCharacters=""/>
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters=""/>
+        <Key android:codes="109" android:keyLabel="m" android:popupCharacters=""/>
+        <Key android:codes="223" android:keyLabel="ß" android:popupCharacters="" ask:shiftedCodes="7838" ask:shiftedKeyLabel="ẞ"/>
+        <Key android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>

--- a/src/main/res/xml/keyboards.xml
+++ b/src/main/res/xml/keyboards.xml
@@ -8,7 +8,9 @@
 	description := some text you would like to add.
 	index := the sort index of this keyboard in the Settings page.
 	 -->
-	<Keyboard nameResId="@string/de_keyboard" layoutResId="@xml/de_qwertz" id="5a1b25da-c17d-4be1-ad8e-3e24333341ec" defaultDictionaryLocale="de" description="Created with tudor and Claude Philipona" index="1"/>
+	<Keyboard nameResId="@string/de_keyboard" layoutResId="@xml/de_qwertz" id="c6b12940-c414-11e9-bb97-0800200c9a66" defaultDictionaryLocale="de" description="AOSP/Gboard like default qwertz" index="1"/>
+	<Keyboard nameResId="@string/de_keyboard_extend" layoutResId="@xml/de_qwertz_extend" id="5a1b25da-c17d-4be1-ad8e-3e24333341ec" defaultDictionaryLocale="de" description="Created with tudor and Claude Philipona" index="1"/>
 	<Keyboard nameResId="@string/de_keyboard_broad" layoutResId="@xml/de_qwertz_broad" id="40f48890-e52f-11e6-9598-0800200c9a66" defaultDictionaryLocale="de" description="Slightly broader layout with umlauts as popups (saving keys)" index="1"/>
 	<Keyboard nameResId="@string/de_keyboard_extra" layoutResId="@xml/de_qwertz_extra" id="5eb23620-e52f-11e6-9598-0800200c9a66" defaultDictionaryLocale="de" description="Slightly broader layout with umlauts as popups (saving keys), also additional characters" index="1"/>
+	<Keyboard nameResId="@string/de_keyboard_qwerty" layoutResId="@xml/de_qwerty" id="574f7971-7d9b-4b20-ab86-940d086c946a" defaultDictionaryLocale="de" description="German QWERTY layout with umlauts as popups (saving keys), also additional characters" index="1"/>
 </Keyboards>


### PR DESCRIPTION
Changed the default german layout(which was iOS-like) to the android-like AOSP layout.
This is the way a keyboard layout for german anroid uers should look like...cause people switch from other android keyboards and not mainly from iOS keyboards. They expect android like layouts as defaults.

I added german extra layouts for extended(ios like) and germany qwerty, to satisfy every user.