### PR TITLE
(fixes 4 issues) Ordinal indicators to Spanish and Portuguese, Shift key in the italian keyboard, and simplified QWERTZ keyboard for Czech.

### DIFF
--- a/languages/brazilian/pack/src/main/res/xml/brazilian_popup_qwerty_e.xml
+++ b/languages/brazilian/pack/src/main/res/xml/brazilian_popup_qwerty_e.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android">
     <Row android:rowEdgeFlags="top">
+        <!-- ë ę ε η € -->
         <Key android:codes="235" android:keyEdgeFlags="left"/>
         <Key android:codes="281"/>
         <Key android:codes="949"/>
@@ -9,6 +11,7 @@
         <Key android:codes="8364" android:keyEdgeFlags="right"/>
     </Row>
     <Row android:rowEdgeFlags="bottom">
+        <!-- 3 è é ē ě ê -->
         <Key android:codes="51" android:keyEdgeFlags="left"/>
         <Key android:codes="232"/>
         <Key android:codes="233"/>

--- a/languages/brazilian/pack/src/main/res/xml/brazilian_qwerty.xml
+++ b/languages/brazilian/pack/src/main/res/xml/brazilian_qwerty.xml
@@ -27,12 +27,12 @@
         <Key android:codes="121" android:popupCharacters="6ýÿψ"/>
         <Key android:codes="117" android:popupKeyboard="@xml/brazilian_popup_qwerty_u"/>
         <Key android:codes="105" android:popupCharacters="8ìíîïłīι*"/>
-        <Key android:codes="111" android:popupCharacters="9òóôǒōõöőøœo"/>
+        <Key android:codes="111" android:popupCharacters="9òóôǒōõöőøœoº"/>
         <Key android:codes="112" android:popupCharacters="0π" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row>
-        <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:popupCharacters="àáâãāäåæąăα"
+        <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:popupCharacters="àáâãāäåæąăαª"
              android:keyEdgeFlags="left"/>
         <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßśŝšșσ"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đďδ"/>

--- a/languages/brazilian/pack/src/main/res/xml/brazilian_qwerty_with_symbols.xml
+++ b/languages/brazilian/pack/src/main/res/xml/brazilian_qwerty_with_symbols.xml
@@ -13,12 +13,12 @@
         <Key android:codes="y" android:popupCharacters="6ýÿ" ask:hintLabel="6"/>
         <Key android:codes="u" android:popupCharacters="7ùúûüŭűūµ" ask:hintLabel="7"/>
         <Key android:codes="i" android:popupCharacters="8ìíîïłīι*" ask:hintLabel="8"/>
-        <Key android:codes="o" android:popupCharacters="9òóôõöøőœō" ask:hintLabel="9"/>
+        <Key android:codes="o" android:popupCharacters="9òóôõöøőœōº" ask:hintLabel="9"/>
         <Key android:codes="p" android:popupCharacters="0¶" ask:hintLabel="0" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row>
-        <Key android:codes="a" android:popupCharacters="\@àáâãäåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
+        <Key android:codes="a" android:popupCharacters="\@àáâãäåæąª" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
         <Key android:codes="s" android:popupCharacters="$§ßśŝš" ask:hintLabel="$"/>
         <Key android:codes="d" android:popupCharacters="#%đď" ask:hintLabel="# %"/>
         <Key android:codes="f" android:popupCharacters="^\u0026" ask:hintLabel="^ \u0026"/>

--- a/languages/czech/pack/src/main/res/values/czech_pack_strings.xml
+++ b/languages/czech/pack/src/main/res/values/czech_pack_strings.xml
@@ -1,11 +1,13 @@
 
 <resources>
     <string name="czech_qwerty_keyboard">Czech qwerty</string>
-    <string name="czech_qwerty_simple_keyboard">Czech</string>
-    <string name="czech_qwertz_keyboard">Czech qwertz</string>
     <string name="czech_qwerty_description">Czech qwerty</string>
+    <string name="czech_qwerty_simple_keyboard">Czech qwerty</string>
     <string name="czech_qwerty_simple_description">Space saving QWERTY</string>
+    <string name="czech_qwertz_keyboard">Czech qwertz</string>
     <string name="czech_qwertz_description">Czech qwertz</string>
+    <string name="czech_qwertz_simple_keyboard">Czech qwertz</string>
+    <string name="czech_qwertz_simple_description">Space saving QWERTZ</string>
     <string name="czech_dictionary">Czech Dictionary</string>
     <string name="czech_qwerty_keyboard_diacritic">Czech qwerty with diacritic keys</string>
     <string name="czech_qwertz_keyboard_diacritic">Czech qwertz with diacritic keys</string>

--- a/languages/czech/pack/src/main/res/xml/czech_keyboards.xml
+++ b/languages/czech/pack/src/main/res/xml/czech_keyboards.xml
@@ -33,6 +33,11 @@
 		index="4" physicalKeyboardMappingResId="@xml/czech_qwerty_physical"
 		defaultDictionaryLocale="cs" />
 
+	<Keyboard nameResId="@string/czech_qwertz_simple_keyboard" iconResId="@drawable/ic_status_czech"
+		layoutResId="@xml/czech_qwertz_simple"  landscapeResId="@xml/czech_qwertz_simple"
+		id="a9dbab70-f04b-11e9-aaef-0800200c9a66" description="@string/czech_qwertz_simple_description"
+		index="3" defaultDictionaryLocale="cs" />
+
 	<Keyboard nameResId="@string/czech_qwertz_keyboard_diacritic" iconResId="@drawable/ic_status_czech"
 		layoutResId="@xml/czech_qwertz_diacritic"  landscapeResId="@xml/czech_qwertz_diacritic"
 		id="6480fe40-5e6b-4ea5-80ba-46ef89ca0670" description="@string/czech_keyboard_diacritic_description"

--- a/languages/czech/pack/src/main/res/xml/czech_qwertz_simple.xml
+++ b/languages/czech/pack/src/main/res/xml/czech_qwertz_simple.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyWidth="10%p">
+<Row>
+    <Key android:codes="q" android:popupCharacters="1" ask:hintLabel="1" android:keyEdgeFlags="left"/>
+    <Key android:codes="w" android:popupCharacters="2" ask:hintLabel="2"/>
+    <Key android:codes="e" android:popupCharacters="éëě3€" ask:hintLabel="3 €"/>
+    <Key android:codes="r" android:popupCharacters="ř4®" ask:hintLabel="4"/>
+    <Key android:codes="t" android:popupCharacters="ť5" ask:hintLabel="5"/>
+    <Key android:codes="z" android:popupCharacters="ž6" ask:hintLabel="6"/>
+    <Key android:codes="u" android:popupCharacters="úůü7" ask:hintLabel="7"/>
+    <Key android:codes="i" android:popupCharacters="í8" ask:hintLabel="8"/>
+    <Key android:codes="o" android:popupCharacters="óö9" ask:hintLabel="9"/>
+    <Key android:codes="p" android:popupCharacters="0" ask:hintLabel="0" android:keyEdgeFlags="right"/>
+</Row>
+<Row>
+    <Key android:codes="a" android:popupCharacters="\@áä" ask:hintLabel="\@"
+         android:keyEdgeFlags="left" android:horizontalGap="5%p"/>
+    <Key android:codes="s" android:popupCharacters="š$ß" ask:hintLabel="$"/>
+    <Key android:codes="d" android:popupCharacters="ď#%" ask:hintLabel="# %"/>
+    <Key android:codes="f" android:popupCharacters="^&amp;" ask:hintLabel="^ &amp;"/>
+    <Key android:codes="g" android:popupCharacters="`°" ask:hintLabel="` °"/>
+    <Key android:codes="h" android:popupCharacters="_~" ask:hintLabel="_ ~"/>
+    <Key android:codes="j" android:popupCharacters="\\|" ask:hintLabel="\\ |"/>
+    <Key android:codes="k" android:popupCharacters="([{" ask:hintLabel="("/>
+    <Key android:codes="l" android:popupCharacters=")]}ľ" ask:hintLabel=")" android:keyEdgeFlags="right"/>
+</Row>
+<Row>
+    <Key android:codes="-1" android:isModifier="true" android:keyWidth="15%p"
+         android:isSticky="true" android:keyEdgeFlags="left"/>
+    <Key android:codes="y" android:popupCharacters="ý/÷" ask:hintLabel="/"/>
+    <Key android:codes="x" android:popupCharacters="*×" ask:hintLabel="*"/>
+    <Key android:codes="c" android:popupCharacters="č-—©" ask:hintLabel="—"/>
+    <Key android:codes="v" android:popupCharacters="+±" ask:hintLabel="+"/>
+    <Key android:codes="b" android:popupCharacters="=≠" ask:hintLabel="="/>
+    <Key android:codes="n" android:popupCharacters="ň&lt;" ask:hintLabel="&lt;"/>
+    <Key android:codes="m" android:popupCharacters="&gt;" ask:hintLabel="&gt;"/>
+    <Key android:codes="-5" android:keyWidth="15%p"
+         android:keyEdgeFlags="right" android:isRepeatable="true"/>
+</Row>
+</Keyboard>

--- a/languages/italian/pack/src/main/res/xml/italian_qwerty.xml
+++ b/languages/italian/pack/src/main/res/xml/italian_qwerty.xml
@@ -38,9 +38,9 @@
     </Row>
 
     <Row>
-        <Key android:codes="-1"
+        <Key android:codes="-1" android:keyWidth="15%p"
             android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
-        <Key android:horizontalGap="5%p" android:codes="122" android:keyLabel="z"/>
+        <Key android:codes="122" android:keyLabel="z"/>
         <Key android:codes="120" android:keyLabel="x"/>
         <Key android:codes="99" android:keyLabel="c"/>
         <Key android:codes="118" android:keyLabel="v"/>

--- a/languages/spain/pack/src/main/res/xml/catalan.xml
+++ b/languages/spain/pack/src/main/res/xml/catalan.xml
@@ -11,13 +11,13 @@
         <Key android:codes="121" android:popupCharacters="6ýÿψ"/>
         <Key android:codes="117" android:popupKeyboard="@xml/popup_qwerty_u"/>
         <Key android:codes="105" android:popupCharacters="8ìíîïłīι*"/>
-        <Key android:codes="111" android:popupCharacters="9òóôǒōõöőøœo"/>
+        <Key android:codes="111" android:popupCharacters="9òóôǒōõöőøœoº"/>
         <Key android:codes="112" android:popupCharacters="0π" />
         <Key android:codes="45" android:keyLabel="-" android:popupCharacters="·" android:keyEdgeFlags="right"/>
     </Row>
-    
+
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="àá" android:keyEdgeFlags="left"/>
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="àáª" android:keyEdgeFlags="left"/>
         <Key android:codes="115" android:keyLabel="s"/>
         <Key android:codes="100" android:keyLabel="d"/>
         <Key android:codes="102" android:keyLabel="f"/>
@@ -28,7 +28,7 @@
         <Key android:codes="108" android:keyLabel="l"/>
         <Key android:codes="231,199" android:keyLabel="&#231;" android:keyEdgeFlags="right"/>
     </Row>
-    
+
     <Row>
         <Key android:keyWidth="15%p" android:codes="-1"
                 android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>

--- a/languages/spain/pack/src/main/res/xml/es_dvorak.xml
+++ b/languages/spain/pack/src/main/res/xml/es_dvorak.xml
@@ -16,8 +16,8 @@
     </Row>
     
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="á" android:keyEdgeFlags="left"/>
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="óòôõöøőœō"/>
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="áª" android:keyEdgeFlags="left"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="óòôõöøőœōº"/>
         <Key android:codes="101" android:keyLabel="e" android:popupCharacters="éèêẽëęẻē€"/>
         <Key android:codes="117" android:keyLabel="u" android:popupCharacters="úùûüűŭūṷůµ"/>
         <Key android:codes="105" android:keyLabel="i" android:popupCharacters="íìî̇ïĩīǐɨι"/>

--- a/languages/spain/pack/src/main/res/xml/es_qwerty.xml
+++ b/languages/spain/pack/src/main/res/xml/es_qwerty.xml
@@ -11,12 +11,12 @@
         <Key android:codes="121" android:popupCharacters="6ýÿψ"/>
         <Key android:codes="117" android:popupKeyboard="@xml/popup_qwerty_u"/>
         <Key android:codes="105" android:popupCharacters="8ìíîïłīι*"/>
-        <Key android:codes="111" android:popupCharacters="9òóôǒōõöőøœo"/>
+        <Key android:codes="111" android:popupCharacters="9òóôǒōõöőøœoº"/>
         <Key android:codes="112" android:popupCharacters="0π" android:keyEdgeFlags="right"/>
     </Row>
-    
+
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="áàâãāäåæąăα" android:keyEdgeFlags="left"/>
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="áàâãāäåæąăαª" android:keyEdgeFlags="left"/>
         <Key android:codes="115" android:keyLabel="s"/>
         <Key android:codes="100" android:keyLabel="d"/>
         <Key android:codes="102" android:keyLabel="f"/>
@@ -27,7 +27,7 @@
         <Key android:codes="108" android:keyLabel="l"/>
         <Key android:codes="241,209" android:keyLabel="ñ" android:keyEdgeFlags="right"/>
     </Row>
-    
+
     <Row>
         <Key android:keyWidth="15%p" android:codes="-1" 
                 android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>

--- a/languages/spain/pack/src/main/res/xml/popup_qwerty_e.xml
+++ b/languages/spain/pack/src/main/res/xml/popup_qwerty_e.xml
@@ -2,6 +2,7 @@
 
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android">
     <Row android:rowEdgeFlags="top">
+        <!-- ëęεη€ -->
         <Key android:codes="235" android:keyEdgeFlags="left"/>
         <Key android:codes="281"/>
         <Key android:codes="949"/>
@@ -9,6 +10,7 @@
         <Key android:codes="8364" android:keyEdgeFlags="right"/>
     </Row>
     <Row android:rowEdgeFlags="bottom">
+        <!-- 3èéēěê -->
         <Key android:codes="51" android:keyEdgeFlags="left"/>
         <Key android:codes="232"/>
         <Key android:codes="233"/>

--- a/languages/spain/pack/src/main/res/xml/spanish_autotext.xml
+++ b/languages/spain/pack/src/main/res/xml/spanish_autotext.xml
@@ -20,6 +20,6 @@
     <!-- this dictionary is used for common typing mistakes -->
     <!-- the attribute 'src' will be replace by the node's value: -->
     <!-- rght will be converted to right -->
-    <word src="rght">right</word>
-    <word src="riht">right</word>
+    <word src="ed">es</word>
+    <word src="wn">en</word>
 </words>


### PR DESCRIPTION
This should:
*close a minor issue that's listed twice in your bug tracker: #143, #287.
*fix the size and position of the Shift key in the italian keyboard (#278).

Also, please close #144; it was already fixed.