### PR TITLE
Quick fix for F-Droid not updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ include ":languages:klingon:pack", ":languages:klingon:apk"
     * replace name and description
     * replace the locale
 1. Set the status-bar icon text at `klingon/pack/build.gradle`: `ext.status_icon_text = "kl"`
-1. Replace the flag at klingon/apk/flag` with a, high-quality, png or svg, image of the flag. It should be named `flag.png` or `flag.svg`. _Note_ that sometimes svg files are not converted correctly, but they will produce highest quality if successful.
+1. Replace the flag at `klingon/apk/flag` with a, high-quality, png or svg, image of the flag. It should be named `flag.png` or `flag.svg`. _Note_ that sometimes svg files are not converted correctly, but they will produce highest quality if successful.
 1. To generate the icons, you'll need ImageMagick installed on your path. Check out the installation [page](https://imagemagick.org/script/download.php) for details.
 1. Generate the icons: `./gradlew :languages:klingon:pack:generateLanguagePackIcons :languages:klingon:apk:generateStoreLogoIcon`. This will generate the following files (which _should_ be checked into the repo):
     * `klingon/pack/src/main/res/drawable-*/ic_status_klingon.png`

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
         mavenCentral()
         mavenLocal()
         maven { url "https://plugins.gradle.org/m2/" }
-        maven { url 'https://dl.bintray.com/novoda-oss/snapshots/' }
         jcenter()
     }
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ tasks.register("generateMarkDownOfLanguagePacks") {
     }
 }
 
+tasks.register("clean") {
+    delete 'buildSrc/build'
+}
+
 tasks.register("copyAnySoftKeyboardBaseLib") {
     group "AnySoftKeyboard"
     description 'Copies several of base aars from this repo into AnySoftKeyboard local repo. Use -PanysoftkeyboardPath=[path/to/AnySoftKeyboard/]'


### PR DESCRIPTION
Edited because I'd forgotten to change the value of `Repo` back to your repo.

```
Categories:
  - Writing
License: Apache-2.0
SourceCode: https://github.com/AnySoftKeyboard/LanguagePack/tree/Czech
IssueTracker: https://github.com/AnySoftKeyboard/LanguagePack/issues
Donate: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=KDYBGNUNMMN94&lc=US&item_name=AnySoftKeyboard

Name: 'AnySoftKeyboard: Czech'
AutoName: AnySoftKeyboard - Czech Language Pack
Description: |-
    Czech keyboard layout with dictionary.

    Dictionary comes from AOSP. The source code is in another branch to the default.

    Install [[com.menny.android.anysoftkeyboard]] first, then select the desired
    layout from AnySoftKeyboard's Settings->Keyboards menu.

RepoType: git
Repo: https://github.com/AnySoftKeyboard/LanguagePack.git

Builds:
  - versionName: 2.0.0
    versionCode: 258
    commit: czech-2.0.0
    gradle:
      - yes
    forceversion: true
    forcevercode: true
    preassemble:
      - :makeDictionary

  - versionName: 2.0.1
    versionCode: 259
    commit: czech-2.0.1
    gradle:
      - yes
    forceversion: true
    forcevercode: true
    prebuild: sed -i -e 's/versionCode versionData.versionCode/versionCode 259/' build.gradle
    preassemble:
      - :makeDictionary

  - versionName: 2.0.2
    versionCode: 260
    commit: czech-2.0.2
    gradle:
      - yes
    forceversion: true
    forcevercode: true
    prebuild: sed -i -e 's/versionCode versionData.versionCode/versionCode 260/' build.gradle
    build:
      - :makeDictionary
      - :build

  - versionName: 4.0.634
    versionCode: 634
    commit: fc1a272efe0839cc812790ddb2224a5088689966
    gradle: yes
    output: add_ons_apks/release/add-on--languages-czech-apk-634.apk
    gradleprops:
      - forceVersionBuildCount=1234

AutoUpdateMode: None
UpdateCheckMode: RepoManifest/Czech
CurrentVersion: 4.0.634
CurrentVersionCode: 634
```

You'll probably want to fix some problems yourself, but at the very least, this compiles with `fdroid build`.

I was tired when I was done investigating at #266. There were three _real_ problems:

- F-Droid has a very strict list of allowed maven repos.
- with your current Gradle configuration, every task creates the folder `buildSrc/build`, which contains intermediate files and binaries that F-Droid doesn't like. And `fdroid build` calls `gradle clean` before building, no matter what you specify.
- Gradle outputs an APK with version code 634, while F-Droid expects 2234.


So I:

- deleted the "unknown" repo at build.gradle (apparently it wasn't needed anymore)
- created a very simple `clean` task, which wastes time and error but doesn't trigger F-Droid detectors; 
- changed the version code from 2234 to 634 again.

You'll probably want to improve the `clean` task, or make it so that those binaries are never built until `build` or `assemble`, or double-check the version code. At least, this works.

I also added a backtick at `README.md` to fix the formatting of a line.