### PR TITLE
Another attempt to fix F-Droid updates.

### DIFF
--- a/gradle/pack_apk.gradle
+++ b/gradle/pack_apk.gradle
@@ -45,9 +45,10 @@ android {
         }
     }
 
+    def keystoreFile = file("/tmp/add_on_pack.keystore")
+
     signingConfigs {
         release {
-            def keystoreFile = file("/tmp/add_on_pack.keystore")
             if (keystoreFile.exists()) {
                 storeFile keystoreFile
                 storePassword System.getenv("PACKS_ALL_KEY_STORE_FILE_PASSWORD")
@@ -55,18 +56,18 @@ android {
                 keyPassword System.getenv("PACKS_ALL_KEY_STORE_FILE_DEFAULT_ALIAS_PASSWORD")
                 println "Using '${storeFile.absolutePath}' to release APK ${path} (with alias '${keyAlias}')."
             } else {
-                println "Could not find '${keystoreFile.absolutePath}' file. Can not sign release APK with release keystore! Using debug."
-                initWith signingConfigs.debug
+                println "Could not find '${keystoreFile.absolutePath}' file. Release APK will not be signed."
             }
         }
     }
 
     buildTypes {
         release {
-            signingConfig signingConfigs.release
+            if (keystoreFile.exists()) {
+                signingConfig signingConfigs.release
+            }
             zipAlignEnabled true
             debuggable false
-
             minifyEnabled false
         }
     }


### PR DESCRIPTION
`fdroid build` works normally by running `gradle assembleRelease` (or `gradle assemble`_(flavour)_`Release`).  `gradle assembleDebug` worked fine, but `gradle assembleRelease` was configured to forcibly create a debug release when no release keystore, and for some reason couldn't automatically create a keystore when forced.

This commit sidesteps all that and makes it so that, when no release keystore is found, it defaults to creating an **unsigned non-debuggable** APK at the usual path (`add_ons_apks`). As far as I can tell, it builds now.

**I also changed forceVersionBuildCounter and the patch number** (4.0.**2234**) because I couldn't figure how to make it different from the version code (just 2234); you might want to check that. (There are ways to force version number or code editing F-Droid's metadata, but that probably will make it more difficult for Google Play.)

Besides those changes, the ending of `metadata/org.herrlado.ask.languagepack.czech.yml` file is pretty much the same, just pointing to this new commit:

```
  - versionName: 4.0.2234
    versionCode: 2234
    commit: d231e418c30c7550f10ef744fc7c478fab298466
    gradle: 
      - yes
    output: add_ons_apks/release/add-on--languages-czech-apk-2234.apk
    gradleprops:
      - forceVersionBuildCount=2834

AutoUpdateMode: None
UpdateCheckMode: RepoManifest
CurrentVersion: 4.0.2234
CurrentVersionCode: 2234
```