### PR TITLE
Fixes for Arabic layouts

### DIFF
--- a/languages/arabic/pack/src/main/res/values/arabic_pack_strings_dont_translate.xml
+++ b/languages/arabic/pack/src/main/res/values/arabic_pack_strings_dont_translate.xml
@@ -5,6 +5,9 @@
 
     <string name="arabic_dictionary">العربية</string>
 
+	<string name="arabic_keyboard">Arabic</string>
+	<string name="arabic_keyboard_description">Created by Yahya Hamidaddin</string>
+
     <string name="linux_keyboard">Arabic/Linux</string>
     <string name="linux_keyboard_description">Arabic/Linux keyboard</string>
 

--- a/languages/arabic/pack/src/main/res/xml/arabic_keyboards.xml
+++ b/languages/arabic/pack/src/main/res/xml/arabic_keyboards.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Keyboards>
+    <Keyboard nameResId="@string/arabic_keyboard" iconResId="@drawable/ic_status_arabic"
+	          layoutResId="@xml/arabic_qwerty" id="141e77eb-bbe9-4e04-b1cc-8b6fd99a5f09"
+			  defaultDictionaryLocale="ar" description="@string/arabic_keyboard_description"
+			  index="1" defaultEnabled="true"
+              physicalKeyboardMappingResId="@xml/arabic_physical" />
     <Keyboard nameResId="@string/aosp_keyboard" iconResId="@drawable/ic_status_arabic"
               layoutResId="@xml/aosp" id="a4402e61-ebc4-4e82-8a7f-9d9b9d3e5f4b"
               defaultDictionaryLocale="ar" description="@string/aosp_keyboard_description"
-              index="1" defaultEnabled="true"
+              index="2" 
               physicalKeyboardMappingResId="@xml/arabic_physical" />
     <Keyboard nameResId="@string/linux_keyboard" iconResId="@drawable/ic_status_arabic"
               layoutResId="@xml/linux" id="26418916-e961-4d30-bc4b-8b704414f0ff"
               defaultDictionaryLocale="ar" description="@string/linux_keyboard_description"
-              index="2"
+              index="3"
               physicalKeyboardMappingResId="@xml/arabic_physical" />
     <Keyboard nameResId="@string/lulua_keyboard" iconResId="@drawable/ic_status_arabic"
               layoutResId="@xml/lulua" id="025e0301-202d-42f6-9f57-a31e12ce0583"
               defaultDictionaryLocale="ar" description="@string/lulua_keyboard_description"
-              index="3"
+              index="4"
               physicalKeyboardMappingResId="@xml/arabic_physical" />
 </Keyboards>

--- a/languages/arabic/pack/src/main/res/xml/arabic_qwerty.xml
+++ b/languages/arabic/pack/src/main/res/xml/arabic_qwerty.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard android:keyWidth="10%p" android:keyHeight="50.0dip" android:horizontalGap="0.0px" android:verticalGap="0.0px"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <Row android:keyWidth="10%p">
+        <Key android:codes="1590" android:popupCharacters="ًٌٍَُِّْ" android:keyEdgeFlags="left" android:keyLabel="ض" />
+        <Key android:codes="1589" android:keyLabel="ص" />
+        <Key android:codes="1602" android:keyLabel="ق" />
+        <Key android:codes="1601" android:popupCharacters="ڤ" android:keyLabel="ف" />
+        <Key android:codes="1594" android:keyLabel="غ" />
+        <Key android:codes="1593" android:keyLabel="ع" />
+        <Key android:codes="1607" android:keyLabel="ه" />
+        <Key android:codes="1582" android:keyLabel="خ" />
+        <Key android:codes="1581" android:keyLabel="ح" />
+        <Key android:codes="1580" android:popupCharacters="چ" android:keyEdgeFlags="right" android:keyLabel="ج" />
+    </Row>
+    <Row android:keyWidth="10%p">
+        <Key android:codes="1588" android:keyEdgeFlags="left" android:keyLabel="ش" />
+        <Key android:codes="1587" android:keyLabel="س" />
+        <Key android:codes="1610" android:popupCharacters="ىئ" android:keyLabel="ي" />
+        <Key android:codes="1576" android:popupCharacters="پ" android:keyLabel="ب" />
+        <Key android:codes="1604" android:keyLabel="ل" />
+        <Key android:codes="1575" android:popupCharacters="أإآء" android:keyLabel="ا" />
+        <Key android:codes="1578" android:keyLabel="ت" />
+        <Key android:codes="1606" android:keyLabel="ن" />
+        <Key android:codes="1605" android:keyLabel="م" />
+        <Key android:codes="1603" android:popupCharacters="گ" android:keyEdgeFlags="right" android:keyLabel="ك" />
+    </Row>
+    <Row android:keyWidth="10%p">
+        <Key android:codes="1592" android:popupCharacters="؟،؛" android:keyEdgeFlags="left" android:keyLabel="ظ" />
+        <Key android:codes="1591" android:keyLabel="ط" />
+        <Key android:codes="1584" android:keyLabel="ذ" />
+        <Key android:codes="1583" android:keyLabel="د" />
+        <Key android:codes="1586" android:popupCharacters="ژ" android:keyLabel="ز" />
+        <Key android:codes="1585" android:keyLabel="ر" />
+        <Key android:codes="1608" android:popupCharacters="ؤ" android:keyLabel="و" />
+        <Key android:codes="1577" android:keyLabel="ة" />
+        <Key android:codes="1579" android:keyEdgeFlags="right" android:keyLabel="ث" />
+        <Key android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true" />
+    </Row>
+</Keyboard>


### PR DESCRIPTION
Here’s a quick fix for the Arabic language pack, see #300. It simply reinstates the previous default layout, extracted from the old APK.

I’m also looking at the AOSP layout again. Is is possible to have custom symbol layers with ASK or would I translate those to popup characters?