### PR TITLE
arabic: Add symbol layer from AOSP layout

### DIFF
--- a/languages/arabic/pack/src/main/res/xml/aosp.xml
+++ b/languages/arabic/pack/src/main/res/xml/aosp.xml
@@ -2,10 +2,13 @@
 <!--
 Derived from Arabic AOSP keyboard, see
 https://android.googlesource.com/platform/packages/inputmethods/LatinIME/+/refs/heads/master/java/res/xml/
+
+Due to the lack of layer support in ASK, popupCharacters include the symbol
+layer as well. Key hints will only include the second layer (symbols), as
+character variations (different number of dots) are obvious.
 -->
-<Keyboard xmlns:android="http://schemas.android.com/apk/res/android" xmlns:ask="http://schemas.android.com/apk/res-auto" xmlns:latin="foobar">
-  <Row android:keyHeight="@integer/key_zero_height" android:keyWidth="7.69%p" android:rowEdgeFlags="top">
-  </Row>
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:ask="http://schemas.android.com/apk/res-auto">
   <Row android:keyWidth="9.091%p">
     <!-- U+0636: "ض" ARABIC LETTER DAD
          U+0661: "١" ARABIC-INDIC DIGIT ONE -->
@@ -45,25 +48,34 @@ https://android.googlesource.com/platform/packages/inputmethods/LatinIME/+/refs/
     <Key android:codes="خ" ask:hintLabel="9" android:popupCharacters="9٩"/>
     <!-- U+062D: "ح" ARABIC LETTER HAH
          U+0660: "٠" ARABIC-INDIC DIGIT ZERO -->
-    <Key android:codes="ح" ask:hintLabel="0" android:popupCharacters="0٠"/>
+    <!-- U+066B: "٫" ARABIC DECIMAL SEPARATOR
+         U+066C: "٬" ARABIC THOUSANDS SEPARATOR -->
+    <Key android:codes="ح" ask:hintLabel="0" android:popupCharacters="0٠&#x066B;&#x066C;"/>
     <!-- U+062C: "ج" ARABIC LETTER JEEM
          U+0686: "چ" ARABIC LETTER TCHEH -->
-    <Key android:codes="ج" android:popupCharacters="چ"/>
+    <Key android:codes="ج" ask:hintLabel=" " android:popupCharacters="چ"/>
   </Row>
   <Row android:keyWidth="9.091%p">
     <!-- U+0634: "ش" ARABIC LETTER SHEEN
          U+069C: "ڜ" ARABIC LETTER SEEN WITH THREE DOTS BELOW AND THREE DOTS ABOVE -->
     <!-- TODO: DroidSansArabic lacks the glyph of U+069C ARABIC LETTER SEEN WITH THREE DOTS BELOW AND THREE DOTS ABOVE -->
-    <Key android:codes="ش" android:popupCharacters="ڜ"/>
+    <Key android:codes="ش" ask:hintLabel="@" android:popupCharacters="ڜ@"/>
     <!-- U+0633: "س" ARABIC LETTER SEEN -->
-    <Key android:codes="س"/>
+    <Key android:codes="س" android:popupCharacters="#" />
     <!-- U+064A: "ي" ARABIC LETTER YEH
          U+0626: "ئ" ARABIC LETTER YEH WITH HAMZA ABOVE
          U+0649: "ى" ARABIC LETTER ALEF MAKSURA -->
-    <Key android:codes="ي" android:popupCharacters="ئى"/>
+    <!-- U+00A2: "¢" CENT SIGN
+         U+00A3: "£" POUND SIGN
+         U+20AC: "€" EURO SIGN
+         U+00A5: "¥" YEN SIGN
+         U+20B1: "₱" PESO SIGN -->
+    <Key android:codes="ي" ask:hintLabel="$" android:popupCharacters="ئى$&#x00A2;&#x00A3;&#x20AC;&#x00A5;&#x20B1;"/>
     <!-- U+0628: "ب" ARABIC LETTER BEH
          U+067E: "پ" ARABIC LETTER PEH -->
-    <Key android:codes="ب" android:popupCharacters="پ"/>
+    <!-- U+066A: "٪" ARABIC PERCENT SIGN -->
+    <!-- U+2030: "‰" PER MILLE SIGN -->
+    <Key android:codes="ب" ask:hintLabel="&#x066A;" android:popupCharacters="پ&#x066A;%&#x2030;"/>
     <!-- U+0644: "ل" ARABIC LETTER LAM
          U+FEFB: "ﻻ" ARABIC LIGATURE LAM WITH ALEF ISOLATED FORM
          U+0627: "ا" ARABIC LETTER ALEF
@@ -73,57 +85,84 @@ https://android.googlesource.com/platform/packages/inputmethods/LatinIME/+/refs/
          U+0625: "إ" ARABIC LETTER ALEF WITH HAMZA BELOW
          U+FEF5: "ﻵ" ARABIC LIGATURE LAM WITH ALEF WITH MADDA ABOVE ISOLATED FORM
          U+0622: "آ" ARABIC LETTER ALEF WITH MADDA ABOVE -->
-    <Key android:codes="ل" android:popupCharacters="ﻻﻷﻹﻵ"/>
+    <Key android:codes="ل" ask:hintLabel="&amp;" android:popupCharacters="ﻻﻷﻹﻵ&amp;"/>
     <!-- U+0627: "ا" ARABIC LETTER ALEF
          U+0622: "آ" ARABIC LETTER ALEF WITH MADDA ABOVE
          U+0621: "ء" ARABIC LETTER HAMZA
          U+0623: "أ" ARABIC LETTER ALEF WITH HAMZA ABOVE
          U+0625: "إ" ARABIC LETTER ALEF WITH HAMZA BELOW
          U+0671: "ٱ" ARABIC LETTER ALEF WASLA -->
-    <Key android:codes="ا" android:popupCharacters="آءأإٱ"/>
+    <!-- U+2013: "–" EN DASH
+         U+2014: "—" EM DASH
+         U+00B7: "·" MIDDLE DOT -->
+    <Key android:codes="ا" ask:hintLabel="&#x2013;" android:popupCharacters="آءأإٱ-_&#x2013;&#x2014;&#x00B7;"/>
     <!-- U+062A: "ت" ARABIC LETTER TEH -->
-    <Key android:codes="ت"/>
+    <!-- U+00B1: "±" PLUS-MINUS SIGN -->
+    <Key android:codes="ت" ask:hintLabel="+" android:popupCharacters="+&#x00B1;" />
     <!-- U+0646: "ن" ARABIC LETTER NOON -->
-    <Key android:codes="ن"/>
+    <!-- U+FD3E: "﴾" ORNATE LEFT PARENTHESIS
+         U+FD3F: "﴿" ORNATE RIGHT PARENTHESIS -->
+    <Key android:codes="ن" ask:hintLabel="(" android:popupCharacters="(&#xFD3E;&lt;{[" />
     <!-- U+0645: "م" ARABIC LETTER MEEM -->
-    <Key android:codes="م"/>
+    <Key android:codes="م" ask:hintLabel=")" android:popupCharacters=")&#xFD3F;&gt;}]" />
     <!-- U+0643: "ك" ARABIC LETTER KAF
          U+06AF: "گ" ARABIC LETTER GAF
          U+06A9: "ک" ARABIC LETTER KEHEH -->
-    <Key android:codes="ك" android:popupCharacters="گک"/>
+    <Key android:codes="ك" ask:hintLabel=" " android:popupCharacters="گک"/>
     <!-- U+0637: "ط" ARABIC LETTER TAH -->
     <Key android:codes="ط"/>
   </Row>
   <Row android:keyWidth="9.091%p">
     <!-- U+0630: "ذ" ARABIC LETTER THAL -->
-    <Key android:codes="ذ"/>
+    <!-- U+2605: "★" BLACK STAR
+         U+066D: "٭" ARABIC FIVE POINTED STAR -->
+    <Key android:codes="ذ" ask:hintLabel="*" android:popupCharacters="*&#x2605;&#x066D;" />
     <!-- U+0621: "ء" ARABIC LETTER HAMZA -->
-    <Key android:codes="ء"/>
+    <Key android:codes="ء" ask:hintLabel="&quot;" android:popupCharacters="&quot;&#x201E;&#x201C;&#x201D;" />
     <!-- U+0624: "ؤ" ARABIC LETTER WAW WITH HAMZA ABOVE -->
-    <Key android:codes="ؤ"/>
+    <Key android:codes="ؤ" ask:hintLabel="'" android:popupCharacters="'&#x201A;&#x2018;&#x2019;" />
     <!-- U+0631: "ر" ARABIC LETTER REH -->
-    <Key android:codes="ر"/>
+    <Key android:codes="ر" android:popupCharacters=":" />
     <!-- U+0649: "ى" ARABIC LETTER ALEF MAKSURA
          U+0626: "ئ" ARABIC LETTER YEH WITH HAMZA ABOVE -->
-    <Key android:codes="ى" android:popupCharacters="ئ"/>
+    <Key android:codes="ى" ask:hintLabel="&#x061B;" android:popupCharacters="ئ&#x061B;;"/>
     <!-- U+0629: "ة" ARABIC LETTER TEH MARBUTA -->
-    <Key android:codes="ة"/>
+    <!-- U+00A1: "¡" INVERTED EXCLAMATION MARK -->
+    <Key android:codes="ة" ask:hintLabel="!" android:popupCharacters="!&#x00A1;" />
     <!-- U+0648: "و" ARABIC LETTER WAW -->
-    <Key android:codes="و"/>
+    <!-- U+00BF: "¿" INVERTED QUESTION MARK -->
+    <Key android:codes="و" ask:hintLabel="&#x061F;" android:popupCharacters="&#x061F;?&#x00BF;" />
     <!-- U+0632: "ز" ARABIC LETTER ZAIN
          U+0698: "ژ" ARABIC LETTER JEH -->
-    <Key android:codes="ز" android:popupCharacters="ژ"/>
+    <Key android:codes="ز" ask:hintLabel=" " android:popupCharacters="ژ"/>
     <!-- U+0638: "ظ" ARABIC LETTER ZAH -->
-    <Key android:codes="ظ"/>
+    <Key android:codes="ظ" android:popupCharacters="" />
     <!-- U+062F: "د" ARABIC LETTER DAL -->
-    <Key android:codes="د"/>
+    <Key android:codes="د" android:popupCharacters="" />
     <Key android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
   </Row>
-  <Row android:keyHeight="@integer/key_normal_height" android:rowEdgeFlags="bottom">
-    <Key android:codes="@integer/key_code_mode_symbols" ask:isFunctional="true" android:isModifier="true" ask:keyDynamicEmblem="text" android:keyEdgeFlags="left" latin:keyWidth="15%p" />
-    <Key android:codes="،" android:popupCharacters=",؛;:()«»" />
-    <Key android:codes="32" android:keyEdgeFlags="left" android:keyWidth="50%p" ask:isFunctional="true"/>
-    <Key android:codes="." android:popupCharacters="؟!…" />
-    <Key android:codes="10" android:keyEdgeFlags="right" android:keyWidth="20%p" ask:isFunctional="true"/>
+  <Row android:keyHeight="@integer/key_normal_height" android:rowEdgeFlags="bottom" android:keyWidth="9.091%p">
+    <Key android:codes="@integer/key_code_mode_symbols" ask:isFunctional="true" android:isModifier="true" ask:keyDynamicEmblem="text" android:keyEdgeFlags="left" />
+	<Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" " />
+    <!-- U+060C: "،" ARABIC COMMA -->
+    <Key android:codes="&#x060C;" ask:hintLabel="/" android:popupCharacters=",_/" />
+    <Key android:codes="32" android:keyEdgeFlags="left" android:keyWidth="45.2%p" ask:isFunctional="true"/>
+    <!-- U+2026: "…" HORIZONTAL ELLIPSIS -->
+    <!-- U+0655: "ٕ" ARABIC HAMZA BELOW
+         U+0654: "ٔ" ARABIC HAMZA ABOVE
+         U+0652: "ْ" ARABIC SUKUN
+         U+064D: "ٍ" ARABIC KASRATAN
+         U+064C: "ٌ" ARABIC DAMMATAN
+         U+064B: "ً" ARABIC FATHATAN
+         U+0651: "ّ" ARABIC SHADDA -->
+    <!-- U+0656: "ٖ" ARABIC SUBSCRIPT ALEF
+         U+0670: "ٰ" ARABIC LETTER SUPERSCRIPT ALEF
+         U+0653: "ٓ" ARABIC MADDAH ABOVE
+         U+0650: "ِ" ARABIC KASRA
+         U+064F: "ُ" ARABIC DAMMA
+         U+064E: "َ" ARABIC FATHA
+         U+0640: "ـ" ARABIC TATWEEL -->
+    <Key android:codes="." ask:hintLabel="&#x0650;&#x064F;&#x064E;" android:popupCharacters="&#x2026;&#x0655;&#x0654;&#x0652;&#x064D;&#x064C;&#x064B;&#x0651;&#x0656;&#x0670;&#x0653;&#x0650;&#x064F;&#x064E;&#x0640;" />
+    <Key android:codes="10" android:keyEdgeFlags="right" android:keyWidth="18.182%p" ask:isFunctional="true"/>
   </Row>
 </Keyboard>


### PR DESCRIPTION
Includes diacritics and a few essential symbols. This should address most of the criticism, but don’t make it the default layout.