### PR TITLE
german: Add NEO2 keyboard layout

### DIFF
--- a/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
+++ b/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
@@ -11,4 +11,6 @@
     <string name="de_keyboard_broad_description">Slightly broader layout with umlauts as popups (saving keys)</string>
     <string name="de_keyboard_extra">German broad+</string>
     <string name="de_keyboard_extra_description">Slightly broader layout with umlauts as popups (saving keys), also additional characters</string>
+    <string name="de_keyboard_neo2">German neo2</string>
+    <string name="de_keyboard_neo2_simple">German neo2 simple</string>
 </resources>

--- a/languages/german/pack/src/main/res/xml/de_neo2.xml
+++ b/languages/german/pack/src/main/res/xml/de_neo2.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016, kertase
+
+    This file is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:ask="http://schemas.android.com/apk/res-auto"
+          android:keyWidth="8%p" android:keyHeight="50dip"
+          android:horizontalGap="0px" android:verticalGap="0px">
+<Row android:rowEdgeFlags="top">
+    <!-- key codes: http://r12a.github.io/apps/conversion/ -->
+    <Key android:codes="49" android:keyLabel="1" ask:shiftedCodes="176" android:keyEdgeFlags="left" android:popupCharacters="°¹ª₁¬"/>
+    <Key android:codes="50" android:keyLabel="2" ask:shiftedCodes="167" android:popupCharacters="§²º₂∨"/>
+    <Key android:codes="51" android:keyLabel="3" ask:shiftedCodes="8467" android:popupCharacters="ℓ³№₃∧"/>
+    <Key android:codes="52" android:keyLabel="4" ask:shiftedCodes="187" android:popupCharacters="»›♀⊥"/>
+    <Key android:codes="53" android:keyLabel="5" ask:shiftedCodes="171" android:popupCharacters="«‹·♂∡"/>
+    <Key android:codes="54" android:keyLabel="6" ask:shiftedCodes="36" android:popupCharacters="$¢£⚥∥"/>
+    <Key android:codes="55" android:keyLabel="7" ask:shiftedCodes="8364" android:popupCharacters="€¥¤ϰ→"/>
+    <Key android:codes="56" android:keyLabel="8" ask:shiftedCodes="8222" android:popupCharacters="„‚\u0009⟨∞"/>
+    <Key android:codes="57" android:keyLabel="9" ask:shiftedCodes="8220" android:popupCharacters="“‘/⟩∝"/>
+    <Key android:codes="48" android:keyLabel="0" ask:shiftedCodes="8221" android:popupCharacters="”’*₀∅"/>
+    <Key android:codes="45" android:keyLabel="-" ask:shiftedCodes="8212" android:popupCharacters="—-‑­"/>
+    <Key android:keyWidth="12%p" android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+</Row>
+<Row>
+    <Key android:horizontalGap="4%p" android:codes="120" android:keyLabel="x" android:keyEdgeFlags="left" android:popupCharacters="…ξΞ"/>
+    <Key android:codes="118" android:keyLabel="v" android:popupCharacters="_√"/>
+    <Key android:codes="108" android:keyLabel="l" android:popupCharacters="[λΛ"/>
+    <Key android:codes="99" android:keyLabel="c" android:popupCharacters="]χℂ"/>
+    <Key android:codes="119" android:keyLabel="w" android:popupCharacters="^ωΩ"/>
+    <Key android:codes="107" android:keyLabel="k" android:popupCharacters="!¡κ×"/>
+    <Key android:codes="104" android:keyLabel="h" android:popupCharacters="\u003c7ψΨ"/>
+    <Key android:codes="103" android:keyLabel="g" android:popupCharacters="\u003e8γΓ"/>
+    <Key android:codes="102" android:keyLabel="f" android:popupCharacters="=9φΦ"/>
+    <Key android:codes="113" android:keyLabel="q" android:popupCharacters="\u0026+ϕℚ"/>
+    <Key android:codes="223" android:keyLabel="ß" ask:shiftedCodes="7838" android:popupCharacters="ſ−ς∘"/>
+    <Key android:codes="769" android:keyLabel="́" ask:shiftedCodes="771" android:keyEdgeFlags="right" android:popupCharacters="\u0300\u0302\u0303\u0327\u030C\u0337\u030A\u030B\u0308\u0307\u0314\u0313\u02DE\u0306\u0304\u0323"/>
+</Row>
+<Row>
+    <Key android:horizontalGap="8%p" android:codes="117" android:keyLabel="u" android:keyEdgeFlags="left" android:popupCharacters="\\⊂"/>
+    <Key android:codes="105" android:keyLabel="i" android:popupCharacters="/ι∫"/>
+    <Key android:codes="97" android:keyLabel="a" android:popupCharacters="{α∀"/>
+    <Key android:codes="101" android:keyLabel="e" android:popupCharacters="}ε∃"/>
+    <Key android:codes="111" android:keyLabel="o" android:popupCharacters="*ο∈"/>
+    <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\?¿σΣ"/>
+    <Key android:codes="110" android:keyLabel="n" android:popupCharacters="(4νℕ"/>
+    <Key android:codes="114" android:keyLabel="r" android:popupCharacters=")5ρℝ"/>
+    <Key android:codes="116" android:keyLabel="t" android:popupCharacters="-6τ∂"/>
+    <Key android:codes="100" android:keyLabel="d" android:popupCharacters=":,δΔ"/>
+    <Key android:codes="121" android:keyLabel="y" android:keyEdgeFlags="right" android:popupCharacters="\@.υ∇"/>
+</Row>
+<Row>
+    <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left" android:keyWidth="12%p"/>
+    <Key android:codes="252" android:keyLabel="ü" android:popupCharacters="#∪"/>
+    <Key android:codes="246" android:keyLabel="ö" android:popupCharacters="$ϵ∩"/>
+    <Key android:codes="228" android:keyLabel="ä" android:popupCharacters="|ηℵ"/>
+    <Key android:codes="112" android:keyLabel="p" android:popupCharacters="~πΠ"/>
+    <Key android:codes="122" android:keyLabel="z" android:popupCharacters="`ζℤ"/>
+    <Key android:codes="98" android:keyLabel="b" android:popupCharacters="+:β⇐"/>
+    <Key android:codes="109" android:keyLabel="m" android:popupCharacters="%1μ⇔"/>
+    <Key android:codes="44" android:keyLabel="," ask:shiftedCodes="8211" android:popupCharacters="–\u00222ϱ⇒"/>
+    <Key android:codes="46" android:keyLabel="." ask:shiftedCodes="8226" android:popupCharacters="•\'3ϑ↦"/>
+    <Key android:codes="106" android:keyLabel="j" android:popupCharacters=";θΘ"/>
+    <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="right" android:keyWidth="8%p"/>
+</Row>
+<Row android:rowEdgeFlags="bottom">
+    <!-- key codes:http://r12a.github.io/apps/conversion/ -->
+    <Key android:isModifier="true" android:codes="-10" ask:longPressCode="-102" ask:isFunctional="true"/>
+    <Key android:codes="-22" android:keyLabel="↑" ask:isFunctional="true" ask:shiftedKeyLabel="↑" android:isRepeatable="true"/>
+    <Key android:codes="-20" android:keyLabel="←" ask:isFunctional="true" ask:shiftedKeyLabel="←" android:isRepeatable="true"/>
+    <Key android:codes="32" android:keyWidth="42%p" ask:isFunctional="true" android:isRepeatable="true"/>
+    <Key android:codes="-21" android:keyLabel="→" ask:isFunctional="true" ask:shiftedKeyLabel="→" android:isRepeatable="true"/>
+    <Key android:codes="-23" android:keyLabel="↓" ask:isFunctional="true" ask:shiftedKeyLabel="↓" android:isRepeatable="true"/>
+    <Key android:codes="10" android:keyEdgeFlags="right" android:keyWidth="18%p" ask:longPressCode="-100"/>
+</Row>
+</Keyboard>
+

--- a/languages/german/pack/src/main/res/xml/de_neo2_simple.xml
+++ b/languages/german/pack/src/main/res/xml/de_neo2_simple.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016, kertase
+
+    This file is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:ask="http://schemas.android.com/apk/res-auto"
+          android:keyWidth="9%p" android:keyHeight="@integer/key_normal_height"
+          android:horizontalGap="0px" android:verticalGap="0px">
+<Row android:rowEdgeFlags="top"  android:keyHeight="@integer/key_short_height">
+    <!-- key codes: http://r12a.github.io/apps/conversion/ -->
+    <Key android:codes="49" android:keyLabel="1" ask:shiftedCodes="176" android:keyEdgeFlags="left" android:popupCharacters="¹ª₁"/>
+    <Key android:codes="50" android:keyLabel="2" ask:shiftedCodes="167" android:popupCharacters="²º₂"/>
+    <Key android:codes="51" android:keyLabel="3" ask:shiftedCodes="8467" android:popupCharacters="³№₃"/>
+    <Key android:codes="52" android:keyLabel="4" ask:shiftedCodes="187" android:popupCharacters="›♀⊥"/>
+    <Key android:codes="53" android:keyLabel="5" ask:shiftedCodes="171" android:popupCharacters="‹·♂"/>
+    <Key android:codes="54" android:keyLabel="6" ask:shiftedCodes="36" android:popupCharacters="¢£⚥"/>
+    <Key android:codes="55" android:keyLabel="7" ask:shiftedCodes="8364" android:popupCharacters="¥¤ϰ"/>
+    <Key android:codes="56" android:keyLabel="8" ask:shiftedCodes="8222" android:popupCharacters="‚⟨∞"/>
+    <Key android:codes="57" android:keyLabel="9" ask:shiftedCodes="8220" android:popupCharacters="‘⟩∝"/>
+    <Key android:codes="48" android:keyLabel="0" ask:shiftedCodes="8221" android:popupCharacters="’₀∅"/>
+    <Key android:codes="45" android:keyLabel="-" ask:shiftedCodes="8212" android:popupCharacters="—‑­" android:keyEdgeFlags="right" />
+</Row>
+<Row>
+    <Key android:codes="120" android:keyLabel="x" android:keyEdgeFlags="left" android:popupCharacters="…ξΞ"/>
+    <Key android:codes="118" android:keyLabel="v" android:popupCharacters="_√∨"/>
+    <Key android:codes="108" android:keyLabel="l" android:popupCharacters="[λΛ"/>
+    <Key android:codes="99" android:keyLabel="c" android:popupCharacters="]χℂ"/>
+    <Key android:codes="119" android:keyLabel="w" android:popupCharacters="^ωΩ"/>
+    <Key android:codes="107" android:keyLabel="k" android:popupCharacters="!¡κ"/>
+    <Key android:codes="104" android:keyLabel="h" android:popupCharacters="\u003cψΨ"/>
+    <Key android:codes="103" android:keyLabel="g" android:popupCharacters="\u003eγΓ"/>
+    <Key android:codes="102" android:keyLabel="f" android:popupCharacters="=φΦ"/>
+    <Key android:codes="113" android:keyLabel="q" android:popupCharacters="\u0026ϕℚ"/>
+    <Key android:codes="223" android:keyLabel="ß" ask:shiftedCodes="7838" android:popupCharacters="ſς∘"/>
+</Row>
+<Row>
+    <Key android:codes="117" android:keyLabel="u" android:keyEdgeFlags="left" android:popupCharacters="\\⊂×"/>
+    <Key android:codes="105" android:keyLabel="i" android:popupCharacters="/ι∫"/>
+    <Key android:codes="97" android:keyLabel="a" android:popupCharacters="{α∀"/>
+    <Key android:codes="101" android:keyLabel="e" android:popupCharacters="}ε∃"/>
+    <Key android:codes="111" android:keyLabel="o" android:popupCharacters="*ο∈"/>
+    <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\?¿σ"/>
+    <Key android:codes="110" android:keyLabel="n" android:popupCharacters="(νℕ"/>
+    <Key android:codes="114" android:keyLabel="r" android:popupCharacters=")ρℝ"/>
+    <Key android:codes="116" android:keyLabel="t" android:popupCharacters="-τ∂"/>
+    <Key android:codes="100" android:keyLabel="d" android:popupCharacters=":δΔ"/>
+    <Key android:codes="121" android:keyLabel="y" android:keyEdgeFlags="right" android:popupCharacters="\@υ∇"/>
+</Row>
+<Row>
+    <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left" android:keyWidth="14%p"/>
+    <Key android:codes="252" android:keyLabel="ü" android:popupCharacters="#∪∧"/>
+    <Key android:codes="246" android:keyLabel="ö" android:popupCharacters="$ϵ∩"/>
+    <Key android:codes="228" android:keyLabel="ä" android:popupCharacters="|ηℵ"/>
+    <Key android:codes="112" android:keyLabel="p" android:popupCharacters="~πΠ"/>
+    <Key android:codes="122" android:keyLabel="z" android:popupCharacters="`ζℤ"/>
+    <Key android:codes="98" android:keyLabel="b" android:popupCharacters="+βΣ"/>
+    <Key android:codes="109" android:keyLabel="m" android:popupCharacters="%μ⇔"/>
+    <Key android:codes="106" android:keyLabel="j" android:popupCharacters=";θΘ"/>
+    <Key android:codes="-5" android:isRepeatable="true" android:keyEdgeFlags="right" android:keyWidth="14%p"/>
+</Row>
+<Row android:rowEdgeFlags="bottom">
+    <!-- key codes:http://r12a.github.io/apps/conversion/ -->
+    <Key android:codes="@integer/key_code_mode_symbols" ask:isFunctional="true" android:keyEdgeFlags="left"/>
+    <Key android:isModifier="true" android:codes="-10" ask:longPressCode="-102" ask:isFunctional="true"/>
+    <Key android:codes="769" android:keyLabel="́" ask:shiftedCodes="771" android:popupCharacters="\u0300\u0302\u0303\u0327\u030C\u0337\u030A\u030B\u0308\u0307\u0314\u0313\u02DE\u0306\u0304\u0323"/>
+    <Key android:codes="32" android:keyWidth="40%p" ask:isFunctional="true" android:isRepeatable="true"/>
+    <Key android:codes="44" android:keyLabel="," ask:shiftedCodes="8211" android:popupCharacters="–\u0022ϱ"/>
+    <Key android:codes="46" android:keyLabel="." ask:shiftedCodes="8226" android:popupCharacters="•\'ϑ"/>
+    <Key android:codes="10" android:keyEdgeFlags="right" android:keyWidth="15%p" ask:longPressCode="-100"/>
+</Row>
+</Keyboard>
+

--- a/languages/german/pack/src/main/res/xml/german_keyboards.xml
+++ b/languages/german/pack/src/main/res/xml/german_keyboards.xml
@@ -15,4 +15,14 @@
               defaultDictionaryLocale="de" description="@string/de_keyboard_extra_description"
               index="3" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/german_physical" />
+    <Keyboard nameResId="@string/de_keyboard_neo2" iconResId="@drawable/ic_status_german"
+              layoutResId="@xml/de_neo2" id="ad1b5ffa-15cc-4ba4-abb7-68df2c0874e7"
+              defaultDictionaryLocale="de"
+              index="4" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/german_neo2_physical" />
+    <Keyboard nameResId="@string/de_keyboard_neo2_simple" iconResId="@drawable/ic_status_german"
+              layoutResId="@xml/de_neo2_simple" id="37606729-66c1-4e04-9968-b32314c7094a"
+              defaultDictionaryLocale="de"
+              index="5" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/german_neo2_physical" />
 </Keyboards>

--- a/languages/german/pack/src/main/res/xml/german_neo2_physical.xml
+++ b/languages/german/pack/src/main/res/xml/german_neo2_physical.xml
@@ -1,0 +1,27 @@
+<!-- Copyright 2016, kertase 
+
+    This file is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
+<PhysicalTranslation 
+QwertyTranslation="\u0078\u0076\u006c\u0063\u0077\u006b\u0068\u0067\u0066\u0071\u0075\u0069\u0061\u0065\u006f\u0073\u006e\u0072\u0074\u00fc\u00f6\u00e4\u0070\u007a\u0062\u006d">
+	<!-- keycode_[ -->
+	<SequenceMapping keySequence="71" targetChar="\u00df"/>
+	<!-- keycode_] -->
+	<SequenceMapping keySequence="72" targetChar="\u00b4"/>
+	<!-- keycode_; -->
+	<SequenceMapping keySequence="74" targetChar="\u0064"/>
+	<!-- keycode_apostroph -->
+	<SequenceMapping keySequence="75" targetChar="\u0079"/>
+	<!-- keycode_m -->
+	<SequenceMapping keySequence="76" targetChar="\u006a"/>
+</PhysicalTranslation>


### PR DESCRIPTION
Files merged from https://github.com/kertase/neo_anysoftkeyboard without functional changes.

There’s a separate package on [f-droid](https://f-droid.org/de/packages/com.anysoftkeyboard.languagepack.neo/), but since it’s a German layout, it belongs here imo.