### PR TITLE
Added alternative Polish keyboard layout

### DIFF
--- a/src/main/res/values-pl/strings.xml
+++ b/src/main/res/values-pl/strings.xml
@@ -6,4 +6,6 @@
 
     <string name="keyboard_qwerty">Polski</string>
     <string name="keyboard_desc_qwerty">Polska klawiatura QWERTY</string>
+    <string name="keyboard_qwerty_alt">Polski - Alternatywna</string>
+    <string name="keyboard_desc_qwerty_alt">Polska klawiatura QWERTY z priorytetem dla polskich znaków specjalnych</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -6,5 +6,7 @@
 
     <string name="keyboard_qwerty">Polish</string>
     <string name="keyboard_desc_qwerty">Polish QWERTY keyboard</string>
+    <string name="keyboard_qwerty_alt">Polish - Alternative</string>
+    <string name="keyboard_desc_qwerty_alt">Alternative Polish QWERTY keyboard with priority given to Polish special characters</string>
 
 </resources>

--- a/src/main/res/xml/keyboards.xml
+++ b/src/main/res/xml/keyboards.xml
@@ -24,4 +24,12 @@
         defaultDictionaryLocale="pl"
         description="@string/keyboard_desc_qwerty"
         index="1"/>
+    <Keyboard
+        nameResId="@string/keyboard_qwerty_alt"
+        iconResId="@drawable/pl"
+        layoutResId="@xml/qwerty_alt"
+        id="1a0a631a-5283-40c0-85bf-d8293f1f6f44"
+        defaultDictionaryLocale="pl"
+        description="@string/keyboard_desc_qwerty_alt"
+        index="2"/>
 </Keyboards>

--- a/src/main/res/xml/qwerty_alt.xml
+++ b/src/main/res/xml/qwerty_alt.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- "android:keyWidth" 
+        specify the default width of a key. In this example, 10% of parent (the
+        whole keyboard)
+-->
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:ask="http://schemas.android.com/apk/res-auto"
+          android:keyWidth="10%p">
+
+    <!-- Key attributes:
+        "android:codes"
+            a comma separated unicode values of the keys. If you specify more
+            than one code, then the other codes are accessible via multi-tap.
+        "android:popupCharacters"
+            characters to show on long-press popup keyboard
+        "android:keyLabel"
+            the text to show on the key. If this attribute is missing, the first
+            code in "android:codes" will be used.
+        "android:horizontalGap"
+            gap to add to the left of this key.
+        "android:isModifier"
+            true/false (default is false) whether this key is a modifier key.
+            Means it will be rendered with a differnt background (shift, delete
+            are example of modifier key)
+        "android:isRepeatable"
+            true/false (default is false) whether this key repeats printing on
+            long press (like the backspace). Setting this to true will disable
+            the long-press (android:popupCharacters) functionality
+        "android:keyWidth"
+            specify the width of this key
+    -->
+    <Row>
+        <Key android:codes="q" android:popupCharacters="1" ask:hintLabel="1" android:keyEdgeFlags="left"/>
+        <Key android:codes="w" android:popupCharacters="2" ask:hintLabel="2"/>
+        <Key android:codes="e" android:popupCharacters="ę3é€" ask:hintLabel="ę"/>
+        <Key android:codes="r" android:popupCharacters="4" ask:hintLabel="4"/>
+        <Key android:codes="t" android:popupCharacters="5" ask:hintLabel="5"/>
+        <Key android:codes="y" android:popupCharacters="6" ask:hintLabel="6"/>
+        <Key android:codes="u" android:popupCharacters="7" ask:hintLabel="7"/>
+        <Key android:codes="i" android:popupCharacters="8" ask:hintLabel="8"/>
+        <Key android:codes="o" android:popupCharacters="ó9" ask:hintLabel="ó"/>
+        <Key android:codes="p" android:popupCharacters="0" ask:hintLabel="0" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:horizontalGap="5%p"
+             android:codes="a" android:popupCharacters="ą\@á" ask:hintLabel="ą" android:keyEdgeFlags="left"/>
+        <Key android:codes="s" android:popupCharacters="ś$" ask:hintLabel="ś"/>
+        <Key android:codes="d" android:popupCharacters="#%" ask:hintLabel="# %" />
+        <Key android:codes="f" android:popupCharacters="^\u0026" ask:hintLabel="^ \u0026"/>
+        <Key android:codes="g" android:popupCharacters="`°" ask:hintLabel="` °"/>
+        <Key android:codes="h" android:popupCharacters="_~" ask:hintLabel="_ ~"/>
+        <Key android:codes="j" android:popupCharacters="\\|" ask:hintLabel="\\ |"/>
+        <Key android:codes="k" android:popupCharacters="(" ask:hintLabel="("/>
+        <Key android:codes="l" android:popupCharacters="ł)" ask:hintLabel="ł"
+             android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <!-- shift -->
+        <Key android:codes="-1" android:keyWidth="15%p"
+             android:isModifier="true" android:isSticky="true"
+             android:keyEdgeFlags="left"/>
+
+        <Key android:codes="z" android:popupCharacters="żź/" ask:hintLabel="ż"/>
+        <Key android:codes="x" android:popupCharacters="*" ask:hintLabel="*"/>
+        <Key android:codes="c" android:popupCharacters="ć-" ask:hintLabel="ć"/>
+        <Key android:codes="v" android:popupCharacters="+" ask:hintLabel="+"/>
+        <Key android:codes="b" android:popupCharacters="\u003D" ask:hintLabel="\u003D"/>
+        <Key android:codes="n" android:popupCharacters="ń&lt;" ask:hintLabel="ń"/>
+        <Key android:codes="m" android:popupCharacters="&gt;" ask:hintLabel="&gt;"/>
+
+        <!-- backspace -->
+        <Key android:keyWidth="15%p" android:codes="-5"
+             android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>


### PR DESCRIPTION
The Polish special characters appear very often in various words, so it would be desirable to have an alternative layout to facilitate a faster and less mistake-prone way of typing them (with the current layout mistakes happen damn often).